### PR TITLE
Findlib and OPAM support

### DIFF
--- a/library/META
+++ b/library/META
@@ -1,0 +1,42 @@
+version = "0.0"
+description = "Universe library for writing interactive games"
+requires = "universe.color universe.image universe.socket universe.world"
+archive(byte) = "universe.cma"
+archive(native) = "universe.cmxa"
+exists_if = "universe.cma"
+
+package "color" (
+  version = "0.0"
+  description = "Color subpackage for Universe library"
+  requires = "lablgtk2.gnomecanvas"
+  archive(byte) = "color.cma"
+  archive(native) = "color.cmxa"
+  exists_if = "color.cma"
+)
+
+package "image" (
+  version = "0.0"
+  description = "Image subpackage for Universe library"
+  requires = "lablgtk2.gnomecanvas"
+  archive(byte) = "image.cma"
+  archive(native) = "image.cmxa"
+  exists_if = "image.cma"
+)
+
+package "socket" (
+  version = "0.0"
+  description = "Socket subpackage for Universe library"
+  requires = "unix"
+  archive(byte) = "socket.cma"
+  archive(native) = "socket.cmxa"
+  exists_if = "socket.cma"
+)
+
+package "world" (
+  version = "0.0"
+  description = "World subpackage for Universe library"
+  requires = "lablgtk2.gnomecanvas"
+  archive(byte) = "world.cma"
+  archive(native) = "world.cmxa"
+  exists_if = "world.cma"
+)

--- a/library/Makefile
+++ b/library/Makefile
@@ -37,3 +37,9 @@ clean :
 	make clean -f Makefile-$(UNIVERSE)
 	cd ocamldoc; make clean
 	rm -Rf doc
+
+install : bcl
+	ocamlfind install universe META $(wildcard *.cma *.mli *.cmxa *.cmi)
+
+uninstall :
+	ocamlfind remove universe

--- a/opam
+++ b/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+name: "universe"
+version: "0.0"
+authors: ["Chihiro Uehara" "Kenichi Asai"]
+homepage: "http://pllab.is.ocha.ac.jp/~asai/Universe/"
+build: [
+  ["cp" "%{lib}%/ocaml-makefile/OCamlMakefile" "."]
+  ["sh" "-c" "cd library && %{make}% bcl ncl"]
+]
+install: ["sh" "-c" "cd library && %{make}% install"]
+remove: ["ocamlfind" "remove" "universe"]
+depends: ["ocamlfind"
+          "conf-gnomecanvas"
+          "lablgtk"
+          "ocaml-makefile"]


### PR DESCRIPTION
- Add a `META` file and `install` and `uninstall` targets to the Makefile
- Add an `opam` file to the root of the repository

After these changes users can install the Universe Library through OPAM as follows:

``` bash
$ opam pin add universe https://github.com/kenichi-asai/Universe
```
