### PR TITLE
fix module dependency.

### DIFF
--- a/library/Makefile-world
+++ b/library/Makefile-world
@@ -1,4 +1,4 @@
-SOURCES = world.mli world.ml
+SOURCES = option.ml world.mli world.ml
 PACKS = cairo2.lablgtk2 lablgtk2.gnomecanvas
 RESULT = world
 OCAMLMAKEFILE = ../OCamlMakefile


### PR DESCRIPTION
”refactor option double match to use combinators.  ”のパッチではビルド後のライブラリ利用に問題がありました。その修正パッチです。
